### PR TITLE
replace accumulator pattern by map

### DIFF
--- a/trachoma/trachoma_functions.py
+++ b/trachoma/trachoma_functions.py
@@ -89,6 +89,13 @@ def stepF_fixed(vals, params, demog, bet):
 
     return vals
 
+def assign_age_group(age):
+    if age > 15 * 52:
+        return 2
+    if age > 9 * 52:
+        return 1
+    return 0
+
 def getlambdaStep(params, Age, bact_load, IndD, bet, demog):
 
     '''
@@ -107,12 +114,7 @@ def getlambdaStep(params, Age, bact_load, IndD, bet, demog):
 
     # scales mixing with other groups
     social_mixing = (params['epsilon'] * np.diag(np.ones(3)) + (1 - params['epsilon'])) * demog_matrix
-    positions = []
-    for i in range(len(Age)):
-        a=np.array([0, 9 * 52, 15 * 52, demog['max_age'] * 52])
-        idx = bisect.bisect(x=Age[i], a=a) - 1
-        positions.append(idx)
-
+    positions = list(map(assign_age_group, Age))
     return np.dot(social_mixing, prevLambda)[positions] * (0.5 + 0.5 * (1 - IndD))
 
 def Reset(Age, demog, params):


### PR DESCRIPTION
In function `trachoma_functions.getLambdaStep`:

```python
positions = [bisect.bisect(x=Age[i], a=np.array([0, 9 * 52, 15 * 52, demog['max_age'] * 52])) - 1 for i in range(len(Age))]
```

Unwrapping the list comprehension, we get:

```python
positions = []
for i in range(len(Age)):
    a=np.array([0, 9 * 52, 15 * 52, demog['max_age'] * 52])
    idx = bisect.bisect(x=Age[i], a=a) - 1
    positions.append(idx)
```

The above creates a new list `positions` which is a mapping to `Age`. Elements of `positions` are `0`, `1` or `2` depending on whether the corresponding `Age` value is within a given age group (0-9yo, 9-15yo, above 15yo).


Profiling shows that creating the np array is costly, followed by call to bisect.

The np array is creating in order to use `bisect` which is likely to be overkill in this situation. Since the above is a map operation, let's use the builtin `map` instead

```python
def assign_age_group(age):
    if age > 15 * 52:
	return 2
    if age > 9 * 52:
	return 1
    return 0

positions = map(assign_age_group, Age)
```

The above kernel runs roughly 100x faster than the `bisect`-based kernel.